### PR TITLE
Feature#230.메인 페이지 api 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	},
 	"dependencies": {
 		"@radix-ui/react-dialog": "^1.0.5",
+		"@radix-ui/react-slot": "^1.0.2",
 		"@tanstack/react-query": "^5.17.19",
 		"@tanstack/react-query-devtools": "^5.17.19",
 		"@types/react-router-dom": "^5.3.3",

--- a/src/apis/item.ts
+++ b/src/apis/item.ts
@@ -2,15 +2,26 @@ import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsRespo
 import { ApiResponse } from '@type/apiResponse';
 
 export const getAdminItems = async (
-	page?: number,
+	page: number,
 ): Promise<ApiResponse<AdminItemsResponseDTO>> => {
 	const response = await fetch(
-		`https://daldal.karmapol.link/api/v1/admin/items?page=${page || 1}`,
+		`https://daldal.karmapol.link/api/v1/admin/items?page=${page}`,
 	).then(res => res.json());
 
 	// if (!response.ok) {
 	// 	throw new Error('Failed to fetch');
 	// }
+
+	return response;
+};
+
+export const crawlAdminItems = async (url: string) => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/items/crawl?url=${url}`,
+		{
+			method: 'POST',
+		},
+	).then(res => res.json());
 
 	return response;
 };

--- a/src/apis/item.ts
+++ b/src/apis/item.ts
@@ -1,0 +1,16 @@
+import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
+
+export const getAdminItems = async (
+	page?: number,
+): Promise<ApiResponse<AdminItemsResponseDTO>> => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/items?page=${page || 1}`,
+	).then(res => res.json());
+
+	// if (!response.ok) {
+	// 	throw new Error('Failed to fetch');
+	// }
+
+	return response;
+};

--- a/src/apis/item.ts
+++ b/src/apis/item.ts
@@ -37,3 +37,25 @@ export const addVideoUrl = async (url: string, id: TableDataId) => {
 
 	return response;
 };
+
+export const registerSuggestedProduct = async (id: TableDataId) => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/items/${id}/suggest`,
+		{
+			method: 'PATCH',
+		},
+	).then(res => res.json());
+
+	return response;
+};
+
+export const unregisterSuggestedProduct = async (id: TableDataId) => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/items/${id}/not-suggest`,
+		{
+			method: 'PATCH',
+		},
+	).then(res => res.json());
+
+	return response;
+};

--- a/src/apis/item.ts
+++ b/src/apis/item.ts
@@ -1,5 +1,6 @@
 import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
+import { TableDataId } from '@type/table';
 
 export const getAdminItems = async (
 	page: number,
@@ -20,6 +21,17 @@ export const crawlAdminItems = async (url: string) => {
 		`https://daldal.karmapol.link/api/v1/admin/items/crawl?url=${url}`,
 		{
 			method: 'POST',
+		},
+	).then(res => res.json());
+
+	return response;
+};
+
+export const addVideoUrl = async (url: string, id: TableDataId) => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/items/${id}/video-url?url=${url}&itemId=${id}`,
+		{
+			method: 'PATCH',
 		},
 	).then(res => res.json());
 

--- a/src/components/atoms/Header.tsx
+++ b/src/components/atoms/Header.tsx
@@ -12,7 +12,7 @@ const Header = () => {
 		<header className="flex justify-between pl-[30px] pr-20 items-center h-20">
 			로고
 			<div className="flex">
-				<NavLink to="/main" className={navLinkStyleByActive}>
+				<NavLink to="/" className={navLinkStyleByActive}>
 					메인페이지
 				</NavLink>
 				<NavLink to="/product" className={navLinkStyleByActive}>

--- a/src/components/atoms/ShowDataButton.tsx
+++ b/src/components/atoms/ShowDataButton.tsx
@@ -6,7 +6,8 @@ import {
 	DialogHeader,
 	DialogTrigger,
 } from '@components/ui/dialog';
-import { useTableDataActions } from '@stores/tableData';
+import { useGetRowDataById } from '@hooks/data';
+import { defaultCrawlingData } from '@stores/tableData';
 import { TableDataId, TableDataKey } from '@type/table';
 
 type ShowDataButtonProps = {
@@ -15,8 +16,7 @@ type ShowDataButtonProps = {
 };
 
 const ShowDataButton = ({ id, style }: ShowDataButtonProps) => {
-	const { getDataById } = useTableDataActions();
-	const data = getDataById(id);
+	const data = useGetRowDataById(id, ['adminItems']) || defaultCrawlingData;
 
 	const renderImageOrImages = (key: TableDataKey) => {
 		const dataInString = data[key as keyof typeof data].toString();

--- a/src/components/atoms/Table.tsx
+++ b/src/components/atoms/Table.tsx
@@ -22,7 +22,7 @@ const Table = ({ columns, datas }: TableProps) => {
 			</thead>
 			<tbody>
 				{datas.map((data, index) => (
-					<tr key={`TableRow#${index}`}>
+					<tr key={`TableRow#${index}${data.id}`}>
 						{columns.map(
 							({ key, style, isEditable = false, isClickPossible = false }) => {
 								return (

--- a/src/components/atoms/TableData.tsx
+++ b/src/components/atoms/TableData.tsx
@@ -61,10 +61,15 @@ const TableData = ({
 
 	return (
 		<td
-			className={twMerge('border overflow-hidden text-center', style)}
+			className={twMerge('border overflow-hidden text-center ', style)}
 			onClick={handleClickTableData}
 		>
-			{renderValueOrInput()}
+			<div className="relative">
+				&nbsp;
+				<div className="absolute left-0 top-0 w-full whitespace-nowrap text-ellipsis">
+					{renderValueOrInput()}
+				</div>
+			</div>
 		</td>
 	);
 };

--- a/src/components/atoms/TableDataInput.tsx
+++ b/src/components/atoms/TableDataInput.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, Dispatch, SetStateAction, KeyboardEvent } from 'react';
 
-import { useCrawlAdminItems } from '@hooks/apis/item';
+import { useAddVideoUrl, useCrawlAdminItems } from '@hooks/apis/item';
 import { TableDataId, TableDataKey, TableDataValue } from '@type/table';
 
 type TableDataInputProps = {
@@ -19,6 +19,7 @@ const TableDataInput = ({
 	id,
 }: TableDataInputProps) => {
 	const { crawlAdminItemsByUrl } = useCrawlAdminItems();
+	const { addVideoUrl } = useAddVideoUrl();
 
 	const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setValue(event.target.value);
@@ -33,6 +34,10 @@ const TableDataInput = ({
 			setIsEditing(false);
 			if (headerKey === 'redirectUrl') {
 				crawlAdminItemsByUrl(String(value));
+			}
+
+			if (headerKey === 'videoUrls') {
+				addVideoUrl({ url: String(value), id });
 			}
 		}
 	};

--- a/src/components/atoms/TableDataInput.tsx
+++ b/src/components/atoms/TableDataInput.tsx
@@ -1,6 +1,11 @@
 import { ChangeEvent, Dispatch, SetStateAction, KeyboardEvent } from 'react';
 
-import { useAddVideoUrl, useCrawlAdminItems } from '@hooks/apis/item';
+import {
+	useAddVideoUrl,
+	useCrawlAdminItems,
+	useRegisterSuggestedProduct,
+	useUnregisterSuggestedProduct,
+} from '@hooks/apis/item';
 import { TableDataId, TableDataKey, TableDataValue } from '@type/table';
 
 type TableDataInputProps = {
@@ -20,6 +25,8 @@ const TableDataInput = ({
 }: TableDataInputProps) => {
 	const { crawlAdminItemsByUrl } = useCrawlAdminItems();
 	const { addVideoUrl } = useAddVideoUrl();
+	const { registerSuggestedProduct } = useRegisterSuggestedProduct();
+	const { unregisterSuggestedProduct } = useUnregisterSuggestedProduct();
 
 	const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setValue(event.target.value);
@@ -38,6 +45,16 @@ const TableDataInput = ({
 
 			if (headerKey === 'videoUrls') {
 				addVideoUrl({ url: String(value), id });
+			}
+
+			if (headerKey === 'isSuggested') {
+				if (value === 'Y') {
+					registerSuggestedProduct(id);
+				} else if (value === 'N') {
+					unregisterSuggestedProduct(id);
+				} else {
+					alert('Y 또는 N을 입력해주세요.');
+				}
 			}
 		}
 	};

--- a/src/components/atoms/TableDataInput.tsx
+++ b/src/components/atoms/TableDataInput.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, Dispatch, SetStateAction, KeyboardEvent } from 'react';
 
+import { useCrawlAdminItems } from '@hooks/apis/item';
 import { TableDataId, TableDataKey, TableDataValue } from '@type/table';
 
 type TableDataInputProps = {
@@ -17,20 +18,22 @@ const TableDataInput = ({
 	headerKey,
 	id,
 }: TableDataInputProps) => {
+	const { crawlAdminItemsByUrl } = useCrawlAdminItems();
+
 	const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setValue(event.target.value);
 	};
 
 	const handleOnBlur = () => {
-		// TODO: blur에도 api post / patch 요청 보내기
 		setIsEditing(false);
 	};
 
 	const handleOnKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
 		if (event.key === 'Enter') {
 			setIsEditing(false);
-			// TODO: enter에도 api post / patch 요청 보내기
-			console.log(headerKey, value, id);
+			if (headerKey === 'redirectUrl') {
+				crawlAdminItemsByUrl(String(value));
+			}
 		}
 	};
 

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -11,7 +11,6 @@ const Routing = () => {
 			<Header />
 			<Routes>
 				<Route path="/" element={<Main />} />
-				<Route path="/main" element={<Main />} />
 				<Route path="/product" element={<Product />} />
 				<Route path="/point" element={<Point />} />
 			</Routes>

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -11,6 +11,7 @@ const Routing = () => {
 			<Header />
 			<Routes>
 				<Route path="/" element={<Main />} />
+				<Route path="/:page" element={<Main />} />
 				<Route path="/product" element={<Product />} />
 				<Route path="/point" element={<Point />} />
 			</Routes>

--- a/src/components/molcules/main/AddRowButton.tsx
+++ b/src/components/molcules/main/AddRowButton.tsx
@@ -1,10 +1,26 @@
+import { useQueryClient } from '@tanstack/react-query';
+
 import ButtonWithIcon from '@components/atoms/ButtonWithIcon';
-import { useTableDataActions } from '@stores/tableData';
+import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsResponseDTO';
+import { defaultCrawlingData } from '@stores/tableData';
+import { ApiResponse } from '@type/apiResponse';
 
 const AddRowButton = () => {
-	const { addNewProduct } = useTableDataActions();
+	const queryClient = useQueryClient();
 	const handleAddColumns = () => {
-		addNewProduct();
+		queryClient.setQueryData(
+			['adminItems'],
+			(prev: ApiResponse<AdminItemsResponseDTO>) => ({
+				...prev,
+				data: {
+					...prev.data,
+					adminItemResponses: [
+						...prev.data.adminItemResponses,
+						defaultCrawlingData,
+					],
+				},
+			}),
+		);
 	};
 
 	return (

--- a/src/components/templates/MainTable.tsx
+++ b/src/components/templates/MainTable.tsx
@@ -21,7 +21,6 @@ const MainTable = ({ page }: MainTalbeProps) => {
 		<div className="flex gap-[34px]">
 			<CrawlingSection datas={data?.adminItemResponses || []} />
 			<EnterDataSection datas={data?.adminItemResponses || []} />
-			{console.log(data)}
 		</div>
 	);
 };

--- a/src/components/templates/MainTable.tsx
+++ b/src/components/templates/MainTable.tsx
@@ -1,20 +1,13 @@
-import { useEffect } from 'react';
-
 import CrawlingSection from '@components/organisms/main/CrawlingSection';
 import EnterDataSection from '@components/organisms/main/EnterDataSection';
 import { useGetAdminItems } from '@hooks/apis/item';
-import { useTableDataActions, useTableDatas } from '@stores/tableData';
 
-const MainTable = () => {
-	const { data, isLoading, isError, error, isSuccess } = useGetAdminItems();
-	const { setDatas } = useTableDataActions();
-	const datas = useTableDatas();
+type MainTalbeProps = {
+	page: number;
+};
 
-	useEffect(() => {
-		if (isSuccess) {
-			setDatas(data?.adminItemResponses);
-		}
-	}, [data?.adminItemResponses, isSuccess, setDatas]);
+const MainTable = ({ page }: MainTalbeProps) => {
+	const { data, isLoading, isError, error } = useGetAdminItems(page);
 
 	if (isLoading) {
 		return <div>로딩중...</div>;
@@ -26,8 +19,9 @@ const MainTable = () => {
 
 	return (
 		<div className="flex gap-[34px]">
-			<CrawlingSection datas={datas} />
-			<EnterDataSection datas={datas} />
+			<CrawlingSection datas={data?.adminItemResponses || []} />
+			<EnterDataSection datas={data?.adminItemResponses || []} />
+			{console.log(data)}
 		</div>
 	);
 };

--- a/src/components/templates/MainTable.tsx
+++ b/src/components/templates/MainTable.tsx
@@ -1,21 +1,15 @@
+import { useQueryClient } from '@tanstack/react-query';
+
 import CrawlingSection from '@components/organisms/main/CrawlingSection';
 import EnterDataSection from '@components/organisms/main/EnterDataSection';
-import { useGetAdminItems } from '@hooks/apis/item';
+import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
 
-type MainTalbeProps = {
-	page: number;
-};
-
-const MainTable = ({ page }: MainTalbeProps) => {
-	const { data, isLoading, isError, error } = useGetAdminItems(page);
-
-	if (isLoading) {
-		return <div>로딩중...</div>;
-	}
-
-	if (isError) {
-		return <div>{error.message}</div>;
-	}
+const MainTable = () => {
+	const queryClient = useQueryClient();
+	const data = queryClient.getQueryData<ApiResponse<AdminItemsResponseDTO>>([
+		'adminItems',
+	])?.data;
 
 	return (
 		<div className="flex gap-[34px]">

--- a/src/components/templates/MainTable.tsx
+++ b/src/components/templates/MainTable.tsx
@@ -1,9 +1,24 @@
 import CrawlingSection from '@components/organisms/main/CrawlingSection';
 import EnterDataSection from '@components/organisms/main/EnterDataSection';
-import { useTableDatas } from '@stores/tableData';
+import { useGetAdminItems } from '@hooks/apis/item';
+import { useTableDataActions, useTableDatas } from '@stores/tableData';
 
 const MainTable = () => {
+	const { data, isLoading, isError, error, isSuccess } = useGetAdminItems();
+	const { setDatas } = useTableDataActions();
 	const datas = useTableDatas();
+
+	if (isLoading) {
+		return <div>로딩중...</div>;
+	}
+
+	if (isError) {
+		return <div>{error.message}</div>;
+	}
+
+	if (isSuccess) {
+		setDatas(data?.adminItemResponses || []);
+	}
 
 	return (
 		<div className="flex gap-[34px]">

--- a/src/components/templates/MainTable.tsx
+++ b/src/components/templates/MainTable.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import CrawlingSection from '@components/organisms/main/CrawlingSection';
 import EnterDataSection from '@components/organisms/main/EnterDataSection';
 import { useGetAdminItems } from '@hooks/apis/item';
@@ -8,16 +10,18 @@ const MainTable = () => {
 	const { setDatas } = useTableDataActions();
 	const datas = useTableDatas();
 
+	useEffect(() => {
+		if (isSuccess) {
+			setDatas(data?.adminItemResponses);
+		}
+	}, [data?.adminItemResponses, isSuccess, setDatas]);
+
 	if (isLoading) {
 		return <div>로딩중...</div>;
 	}
 
 	if (isError) {
 		return <div>{error.message}</div>;
-	}
-
-	if (isSuccess) {
-		setDatas(data?.adminItemResponses || []);
 	}
 
 	return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,39 +1,9 @@
 import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
+import { type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
+import { buttonVariants } from '@constants/shadcn';
 import { cn } from '@utils/shadcn';
-
-const buttonVariants = cva(
-	'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 dark:focus-visible:ring-gray-300',
-	{
-		variants: {
-			variant: {
-				default:
-					'bg-gray-900 text-gray-50 hover:bg-gray-900/90 dark:bg-gray-50 dark:text-gray-900 dark:hover:bg-gray-50/90',
-				destructive:
-					'bg-red-500 text-gray-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-gray-50 dark:hover:bg-red-900/90',
-				outline:
-					'border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50',
-				secondary:
-					'bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800/80',
-				ghost:
-					'hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-50',
-				link: 'text-gray-900 underline-offset-4 hover:underline dark:text-gray-50',
-			},
-			size: {
-				default: 'h-10 px-4 py-2',
-				sm: 'h-9 rounded-md px-3',
-				lg: 'h-11 rounded-md px-8',
-				icon: 'h-10 w-10',
-			},
-		},
-		defaultVariants: {
-			variant: 'default',
-			size: 'default',
-		},
-	},
-);
 
 export interface ButtonProps
 	extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -41,7 +11,7 @@ export interface ButtonProps
 	asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 	({ className, variant, size, asChild = false, ...props }, ref) => {
 		const Comp = asChild ? Slot : 'button';
 		return (
@@ -54,5 +24,3 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 	},
 );
 Button.displayName = 'Button';
-
-export { Button, buttonVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "utils/"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 dark:focus-visible:ring-gray-300",
+  {
+    variants: {
+      variant: {
+        default: "bg-gray-900 text-gray-50 hover:bg-gray-900/90 dark:bg-gray-50 dark:text-gray-900 dark:hover:bg-gray-50/90",
+        destructive:
+          "bg-red-500 text-gray-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-gray-50 dark:hover:bg-red-900/90",
+        outline:
+          "border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50",
+        secondary:
+          "bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800/80",
+        ghost: "hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-50",
+        link: "text-gray-900 underline-offset-4 hover:underline dark:text-gray-50",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,56 +1,58 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
-import { cn } from "utils/"
+import { cn } from '@utils/shadcn';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 dark:focus-visible:ring-gray-300",
-  {
-    variants: {
-      variant: {
-        default: "bg-gray-900 text-gray-50 hover:bg-gray-900/90 dark:bg-gray-50 dark:text-gray-900 dark:hover:bg-gray-50/90",
-        destructive:
-          "bg-red-500 text-gray-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-gray-50 dark:hover:bg-red-900/90",
-        outline:
-          "border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50",
-        secondary:
-          "bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800/80",
-        ghost: "hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-50",
-        link: "text-gray-900 underline-offset-4 hover:underline dark:text-gray-50",
-      },
-      size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+	'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 dark:focus-visible:ring-gray-300',
+	{
+		variants: {
+			variant: {
+				default:
+					'bg-gray-900 text-gray-50 hover:bg-gray-900/90 dark:bg-gray-50 dark:text-gray-900 dark:hover:bg-gray-50/90',
+				destructive:
+					'bg-red-500 text-gray-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-gray-50 dark:hover:bg-red-900/90',
+				outline:
+					'border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50',
+				secondary:
+					'bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800/80',
+				ghost:
+					'hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-50',
+				link: 'text-gray-900 underline-offset-4 hover:underline dark:text-gray-50',
+			},
+			size: {
+				default: 'h-10 px-4 py-2',
+				sm: 'h-9 rounded-md px-3',
+				lg: 'h-11 rounded-md px-8',
+				icon: 'h-10 w-10',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default',
+		},
+	},
+);
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+	extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+		VariantProps<typeof buttonVariants> {
+	asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+	({ className, variant, size, asChild = false, ...props }, ref) => {
+		const Comp = asChild ? Slot : 'button';
+		return (
+			<Comp
+				className={cn(buttonVariants({ variant, size, className }))}
+				ref={ref}
+				{...props}
+			/>
+		);
+	},
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "utils/"
+import { ButtonProps, buttonVariants } from "components//ui/button"
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn("mx-auto flex w-full justify-center", className)}
+    {...props}
+  />
+)
+Pagination.displayName = "Pagination"
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex flex-row items-center gap-1", className)}
+    {...props}
+  />
+))
+PaginationContent.displayName = "PaginationContent"
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("", className)} {...props} />
+))
+PaginationItem.displayName = "PaginationItem"
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<ButtonProps, "size"> &
+  React.ComponentProps<"a">
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? "page" : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? "outline" : "ghost",
+        size,
+      }),
+      className
+    )}
+    {...props}
+  />
+)
+PaginationLink.displayName = "PaginationLink"
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronLeft className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+)
+PaginationPrevious.displayName = "PaginationPrevious"
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRight className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationNext.displayName = "PaginationNext"
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    aria-hidden
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+)
+PaginationEllipsis.displayName = "PaginationEllipsis"
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,117 +1,117 @@
-import * as React from "react"
-import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
+import * as React from 'react';
 
-import { cn } from "utils/"
-import { ButtonProps, buttonVariants } from "components//ui/button"
+import { cn } from '@utils/shadcn';
+import { ButtonProps, buttonVariants } from 'components//ui/button';
 
-const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
-  <nav
-    role="navigation"
-    aria-label="pagination"
-    className={cn("mx-auto flex w-full justify-center", className)}
-    {...props}
-  />
-)
-Pagination.displayName = "Pagination"
+const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
+	<nav
+		role="navigation"
+		aria-label="pagination"
+		className={cn('mx-auto flex w-full justify-center', className)}
+		{...props}
+	/>
+);
+Pagination.displayName = 'Pagination';
 
 const PaginationContent = React.forwardRef<
-  HTMLUListElement,
-  React.ComponentProps<"ul">
+	HTMLUListElement,
+	React.ComponentProps<'ul'>
 >(({ className, ...props }, ref) => (
-  <ul
-    ref={ref}
-    className={cn("flex flex-row items-center gap-1", className)}
-    {...props}
-  />
-))
-PaginationContent.displayName = "PaginationContent"
+	<ul
+		ref={ref}
+		className={cn('flex flex-row items-center gap-1', className)}
+		{...props}
+	/>
+));
+PaginationContent.displayName = 'PaginationContent';
 
 const PaginationItem = React.forwardRef<
-  HTMLLIElement,
-  React.ComponentProps<"li">
+	HTMLLIElement,
+	React.ComponentProps<'li'>
 >(({ className, ...props }, ref) => (
-  <li ref={ref} className={cn("", className)} {...props} />
-))
-PaginationItem.displayName = "PaginationItem"
+	<li ref={ref} className={cn('', className)} {...props} />
+));
+PaginationItem.displayName = 'PaginationItem';
 
 type PaginationLinkProps = {
-  isActive?: boolean
-} & Pick<ButtonProps, "size"> &
-  React.ComponentProps<"a">
+	isActive?: boolean;
+} & Pick<ButtonProps, 'size'> &
+	React.ComponentProps<'a'>;
 
 const PaginationLink = ({
-  className,
-  isActive,
-  size = "icon",
-  ...props
+	className,
+	isActive,
+	size = 'icon',
+	...props
 }: PaginationLinkProps) => (
-  <a
-    aria-current={isActive ? "page" : undefined}
-    className={cn(
-      buttonVariants({
-        variant: isActive ? "outline" : "ghost",
-        size,
-      }),
-      className
-    )}
-    {...props}
-  />
-)
-PaginationLink.displayName = "PaginationLink"
+	<a
+		aria-current={isActive ? 'page' : undefined}
+		className={cn(
+			buttonVariants({
+				variant: isActive ? 'outline' : 'ghost',
+				size,
+			}),
+			className,
+		)}
+		{...props}
+	/>
+);
+PaginationLink.displayName = 'PaginationLink';
 
 const PaginationPrevious = ({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to previous page"
-    size="default"
-    className={cn("gap-1 pl-2.5", className)}
-    {...props}
-  >
-    <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
-  </PaginationLink>
-)
-PaginationPrevious.displayName = "PaginationPrevious"
+	<PaginationLink
+		aria-label="Go to previous page"
+		size="default"
+		className={cn('gap-1 pl-2.5', className)}
+		{...props}
+	>
+		<ChevronLeft className="h-4 w-4" />
+		<span>Previous</span>
+	</PaginationLink>
+);
+PaginationPrevious.displayName = 'PaginationPrevious';
 
 const PaginationNext = ({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to next page"
-    size="default"
-    className={cn("gap-1 pr-2.5", className)}
-    {...props}
-  >
-    <span>Next</span>
-    <ChevronRight className="h-4 w-4" />
-  </PaginationLink>
-)
-PaginationNext.displayName = "PaginationNext"
+	<PaginationLink
+		aria-label="Go to next page"
+		size="default"
+		className={cn('gap-1 pr-2.5', className)}
+		{...props}
+	>
+		<span>Next</span>
+		<ChevronRight className="h-4 w-4" />
+	</PaginationLink>
+);
+PaginationNext.displayName = 'PaginationNext';
 
 const PaginationEllipsis = ({
-  className,
-  ...props
-}: React.ComponentProps<"span">) => (
-  <span
-    aria-hidden
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
-  </span>
-)
-PaginationEllipsis.displayName = "PaginationEllipsis"
+	className,
+	...props
+}: React.ComponentProps<'span'>) => (
+	<span
+		aria-hidden
+		className={cn('flex h-9 w-9 items-center justify-center', className)}
+		{...props}
+	>
+		<MoreHorizontal className="h-4 w-4" />
+		<span className="sr-only">More pages</span>
+	</span>
+);
+PaginationEllipsis.displayName = 'PaginationEllipsis';
 
 export {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-}
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+};

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,8 +1,8 @@
 import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
 import * as React from 'react';
 
+import { ButtonProps, buttonVariants } from '@components/ui/button';
 import { cn } from '@utils/shadcn';
-import { ButtonProps, buttonVariants } from 'components//ui/button';
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
 	<nav

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,7 +1,8 @@
 import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
 import * as React from 'react';
 
-import { ButtonProps, buttonVariants } from '@components/ui/button';
+import { ButtonProps } from '@components/ui/button';
+import { buttonVariants } from '@constants/shadcn';
 import { cn } from '@utils/shadcn';
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (

--- a/src/constants/columns.ts
+++ b/src/constants/columns.ts
@@ -1,7 +1,7 @@
 import { TableColumnList } from '@type/table';
 
 export const crawlingReadOnlyTableColumns: TableColumnList = [
-	{ name: '상품명', key: 'detail', style: 'w-full ' },
+	{ name: '상품명', key: 'title', style: 'w-full ' },
 	{ name: '상품 가격', key: 'price', style: 'w-max-[141px] w-full ' },
 	{
 		name: '대표 이미지',
@@ -36,7 +36,7 @@ export const crawlingWritableTableColumns: TableColumnList = [
 	},
 	{
 		name: 'Y/N',
-		key: 'isMDPick',
+		key: 'isSuggested',
 		style: 'w-max-[125px] w-full ',
 		isEditable: true,
 	},

--- a/src/constants/shadcn.ts
+++ b/src/constants/shadcn.ts
@@ -1,0 +1,32 @@
+import { cva } from 'class-variance-authority';
+
+export const buttonVariants = cva(
+	'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 dark:focus-visible:ring-gray-300',
+	{
+		variants: {
+			variant: {
+				default:
+					'bg-gray-900 text-gray-50 hover:bg-gray-900/90 dark:bg-gray-50 dark:text-gray-900 dark:hover:bg-gray-50/90',
+				destructive:
+					'bg-red-500 text-gray-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-gray-50 dark:hover:bg-red-900/90',
+				outline:
+					'border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50',
+				secondary:
+					'bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800/80',
+				ghost:
+					'hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-50',
+				link: 'text-gray-900 underline-offset-4 hover:underline dark:text-gray-50',
+			},
+			size: {
+				default: 'h-10 px-4 py-2',
+				sm: 'h-9 rounded-md px-3',
+				lg: 'h-11 rounded-md px-8',
+				icon: 'h-10 w-10',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default',
+		},
+	},
+);

--- a/src/hooks/apis/item.ts
+++ b/src/hooks/apis/item.ts
@@ -1,11 +1,23 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getAdminItems } from '@apis/item';
+import { crawlAdminItems, getAdminItems } from '@apis/item';
 
-export const useGetAdminItems = (page?: number) => {
+export const useGetAdminItems = (page: number = 1) => {
 	return useQuery({
-		queryKey: ['adminItems', page],
+		queryKey: ['adminItems'],
 		queryFn: () => getAdminItems(page),
 		select: data => data.data,
 	});
+};
+
+export const useCrawlAdminItems = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation({
+		mutationKey: ['adminItems'],
+		mutationFn: (url: string) => crawlAdminItems(url),
+		onSuccess: () =>
+			queryClient.invalidateQueries({ queryKey: ['adminItems'] }),
+	});
+
+	return { crawlAdminItemsByUrl: mutate };
 };

--- a/src/hooks/apis/item.ts
+++ b/src/hooks/apis/item.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getAdminItems } from '@apis/item';
+
+export const useGetAdminItems = (page?: number) => {
+	return useQuery({
+		queryKey: ['adminItems', page],
+		queryFn: () => getAdminItems(page),
+		select: data => data.data,
+	});
+};

--- a/src/hooks/apis/item.ts
+++ b/src/hooks/apis/item.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { crawlAdminItems, getAdminItems } from '@apis/item';
+import { addVideoUrl, crawlAdminItems, getAdminItems } from '@apis/item';
+import { AddYoutubeUrlRequestDTO } from '@models/crawling/request/addYoutubeUrlRequestDTO';
 
 export const useGetAdminItems = (page: number = 1) => {
 	return useQuery({
@@ -20,4 +21,16 @@ export const useCrawlAdminItems = () => {
 	});
 
 	return { crawlAdminItemsByUrl: mutate };
+};
+
+export const useAddVideoUrl = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation({
+		mutationKey: ['adminItems'],
+		mutationFn: ({ url, id }: AddYoutubeUrlRequestDTO) => addVideoUrl(url, id),
+		onSuccess: () =>
+			queryClient.invalidateQueries({ queryKey: ['adminItems'] }),
+	});
+
+	return { addVideoUrl: mutate };
 };

--- a/src/hooks/apis/item.ts
+++ b/src/hooks/apis/item.ts
@@ -1,9 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { addVideoUrl, crawlAdminItems, getAdminItems } from '@apis/item';
+import {
+	addVideoUrl,
+	crawlAdminItems,
+	getAdminItems,
+	registerSuggestedProduct,
+	unregisterSuggestedProduct,
+} from '@apis/item';
 import { AddYoutubeUrlRequestDTO } from '@models/crawling/request/addYoutubeUrlRequestDTO';
+import { TableDataId } from '@type/table';
 
-export const useGetAdminItems = (page: number = 1) => {
+const useGetAdminItems = (page: number = 1) => {
 	return useQuery({
 		queryKey: ['adminItems'],
 		queryFn: () => getAdminItems(page),
@@ -11,7 +18,7 @@ export const useGetAdminItems = (page: number = 1) => {
 	});
 };
 
-export const useCrawlAdminItems = () => {
+const useCrawlAdminItems = () => {
 	const queryClient = useQueryClient();
 	const { mutate } = useMutation({
 		mutationKey: ['adminItems'],
@@ -23,7 +30,7 @@ export const useCrawlAdminItems = () => {
 	return { crawlAdminItemsByUrl: mutate };
 };
 
-export const useAddVideoUrl = () => {
+const useAddVideoUrl = () => {
 	const queryClient = useQueryClient();
 	const { mutate } = useMutation({
 		mutationKey: ['adminItems'],
@@ -33,4 +40,36 @@ export const useAddVideoUrl = () => {
 	});
 
 	return { addVideoUrl: mutate };
+};
+
+const useRegisterSuggestedProduct = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation({
+		mutationKey: ['adminItems'],
+		mutationFn: (id: TableDataId) => registerSuggestedProduct(id),
+		onSuccess: () =>
+			queryClient.invalidateQueries({ queryKey: ['adminItems'] }),
+	});
+
+	return { registerSuggestedProduct: mutate };
+};
+
+const useUnregisterSuggestedProduct = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation({
+		mutationKey: ['adminItems'],
+		mutationFn: (id: TableDataId) => unregisterSuggestedProduct(id),
+		onSuccess: () =>
+			queryClient.invalidateQueries({ queryKey: ['adminItems'] }),
+	});
+
+	return { unregisterSuggestedProduct: mutate };
+};
+
+export {
+	useGetAdminItems,
+	useCrawlAdminItems,
+	useAddVideoUrl,
+	useRegisterSuggestedProduct,
+	useUnregisterSuggestedProduct,
 };

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -1,0 +1,14 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
+import { TableDataId } from '@type/table';
+
+export const useGetRowDataById = (id: TableDataId, queryKey: string[]) => {
+	const queryClient = useQueryClient();
+	const data =
+		queryClient.getQueryData<ApiResponse<AdminItemsResponseDTO>>(queryKey)?.data
+			.adminItemResponses;
+	const rowData = data?.filter(row => row.id === id)[0];
+	return rowData;
+};

--- a/src/mocks/crawling.ts
+++ b/src/mocks/crawling.ts
@@ -5,7 +5,7 @@ export const crawlingTableMockData: (
 	id: TableDataId,
 ) => CrawlingTableData = id => ({
 	id: id === 'new' ? Math.random() : id,
-	detail: '상품 상세 설명',
+	title: '상품 상세 설명',
 	thumbnailUrl: 'https://via.placeholder.com/150',
 	categoryType: '카테고리',
 	imageUrls: [
@@ -17,7 +17,7 @@ export const crawlingTableMockData: (
 		'https://via.placeholder.com/150',
 	],
 	redirectUrl: 'https://via.placeholder.com/150',
-	isMDPick: true,
+	isSuggested: true,
 	isOpen: true,
 	price: 10000,
 });

--- a/src/models/crawling/entity/crawling.ts
+++ b/src/models/crawling/entity/crawling.ts
@@ -2,14 +2,14 @@ import { TableDataId } from '@type/table';
 
 export type CrawlingTableData = {
 	id: TableDataId;
-	detail: string;
+	title: string;
+	redirectUrl: string;
+	categoryType: string;
+	isSuggested: boolean;
 	price: number;
 	thumbnailUrl: string;
 	imageUrls: string[];
-	categoryType: string;
 	videoUrls: string[];
-	redirectUrl: string;
-	isMDPick: boolean;
 	isOpen: boolean;
 };
 

--- a/src/models/crawling/request/addYoutubeUrlRequestDTO.ts
+++ b/src/models/crawling/request/addYoutubeUrlRequestDTO.ts
@@ -1,0 +1,6 @@
+import { TableDataId } from '@type/table';
+
+export type AddYoutubeUrlRequestDTO = {
+	url: string;
+	id: TableDataId;
+};

--- a/src/models/crawling/response/adminItemsResponseDTO.ts
+++ b/src/models/crawling/response/adminItemsResponseDTO.ts
@@ -1,0 +1,18 @@
+export type AdminItem = {
+	id: number;
+	title: string;
+	redirectUrl: string;
+	categoryType: string;
+	isSuggested: boolean;
+	price: number;
+	thumbnailUrl: string;
+	imageUrls: string[];
+	videoUrls: string[];
+};
+
+export type AdminItemList = AdminItem[];
+
+export type AdminItemsResponseDTO = {
+	lastPage: number;
+	adminItemResponses: AdminItemList;
+};

--- a/src/models/crawling/response/adminItemsResponseDTO.ts
+++ b/src/models/crawling/response/adminItemsResponseDTO.ts
@@ -14,6 +14,6 @@ export type AdminItem = {
 export type AdminItemList = AdminItem[];
 
 export type AdminItemsResponseDTO = {
-	lastPage: number;
+	lastPageNum: number;
 	adminItemResponses: AdminItemList;
 };

--- a/src/models/crawling/response/adminItemsResponseDTO.ts
+++ b/src/models/crawling/response/adminItemsResponseDTO.ts
@@ -8,6 +8,7 @@ export type AdminItem = {
 	thumbnailUrl: string;
 	imageUrls: string[];
 	videoUrls: string[];
+	isOpen: false;
 };
 
 export type AdminItemList = AdminItem[];

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -11,20 +11,34 @@ import {
 	PaginationNext,
 	PaginationPrevious,
 } from '@components/ui/pagination';
+import { useGetAdminItems } from '@hooks/apis/item';
 import PageLayout from '@layouts/PageLayout';
 
 const Main = () => {
 	const params = useParams();
+
 	const page = params.page || 1;
+	const { data, isLoading, isError, error } = useGetAdminItems(+page);
+	const lastPage = data?.lastPageNum || 1;
+
+	if (isLoading) {
+		return <div>로딩중...</div>;
+	}
+
+	if (isError) {
+		return <div>{error.message}</div>;
+	}
 
 	return (
 		<PageLayout>
 			<AddRowButton />
-			<MainTable page={+page} />
+			<MainTable />
 			<Pagination>
 				<PaginationContent>
 					<PaginationItem>
-						<PaginationPrevious>Previous</PaginationPrevious>
+						<PaginationPrevious href={`${+page - 1 > 0 ? +page - 1 : 1}`}>
+							Previous
+						</PaginationPrevious>
 					</PaginationItem>
 					<PaginationItem>
 						<PaginationLink href={`${page}`}>{page}</PaginationLink>
@@ -33,7 +47,11 @@ const Main = () => {
 						<PaginationEllipsis />
 					</PaginationItem>
 					<PaginationItem>
-						<PaginationNext>Next</PaginationNext>
+						<PaginationNext
+							href={`${+page + 1 <= lastPage ? +page + 1 : lastPage}`}
+						>
+							Next
+						</PaginationNext>
 					</PaginationItem>
 				</PaginationContent>
 			</Pagination>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,12 +1,42 @@
+import { useParams } from 'react-router-dom';
+
 import AddRowButton from '@components/molcules/main/AddRowButton';
 import MainTable from '@components/templates/MainTable';
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from '@components/ui/pagination';
 import PageLayout from '@layouts/PageLayout';
 
 const Main = () => {
+	const params = useParams();
+	const page = params.page || 1;
+
 	return (
 		<PageLayout>
 			<AddRowButton />
 			<MainTable />
+			<Pagination>
+				<PaginationContent>
+					<PaginationItem>
+						<PaginationPrevious>Previous</PaginationPrevious>
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationLink href={`${page}`}>{page}</PaginationLink>
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationEllipsis />
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationNext>Next</PaginationNext>
+					</PaginationItem>
+				</PaginationContent>
+			</Pagination>
 		</PageLayout>
 	);
 };

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -20,7 +20,7 @@ const Main = () => {
 	return (
 		<PageLayout>
 			<AddRowButton />
-			<MainTable />
+			<MainTable page={+page} />
 			<Pagination>
 				<PaginationContent>
 					<PaginationItem>

--- a/src/stores/tableData.ts
+++ b/src/stores/tableData.ts
@@ -1,19 +1,18 @@
 import { create } from 'zustand';
 
-import { crawlingTableMockData } from '@mocks/crawling';
 import { TableData, TableDataId, TableDataList } from '@type/table';
 
 const defaultCrawlingData: TableData = {
 	id: 'new',
-	detail: '',
+	title: '',
 	thumbnailUrl: '',
 	categoryType: '',
 	imageUrls: [''],
 	videoUrls: [''],
 	redirectUrl: '',
-	isMDPick: false,
-	isOpen: false,
+	isSuggested: false,
 	price: 0,
+	isOpen: false,
 };
 
 type TableDataStore = {
@@ -27,7 +26,7 @@ type TableDataStore = {
 };
 
 const useTableDataStore = create<TableDataStore>((set, get) => ({
-	datas: [crawlingTableMockData(1)],
+	datas: [],
 	actions: {
 		isNewProductExist: () => {
 			const datas = get().datas;

--- a/src/stores/tableData.ts
+++ b/src/stores/tableData.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 import { TableData, TableDataId, TableDataList } from '@type/table';
 
-const defaultCrawlingData: TableData = {
+export const defaultCrawlingData: TableData = {
 	id: 'new',
 	title: '',
 	thumbnailUrl: '',

--- a/src/type/apiResponse.ts
+++ b/src/type/apiResponse.ts
@@ -1,0 +1,6 @@
+export type ApiResponse<T = object> = {
+	// errorCode: string;
+	message: string;
+	status: 'noContent' | 'ok' | 'created';
+	data: T;
+};

--- a/src/utils/formatData.ts
+++ b/src/utils/formatData.ts
@@ -5,7 +5,7 @@ export const getFormattedTableData = (
 	value: TableDataValue,
 ) => {
 	switch (headerKey) {
-		case 'isMDPick':
+		case 'isSuggested':
 			return value ? 'Y' : 'N';
 		case 'isRefund':
 			return value ? 'Y' : 'N';

--- a/yarn.lock
+++ b/yarn.lock
@@ -366,7 +366,7 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.2"
 
-"@radix-ui/react-slot@1.0.2":
+"@radix-ui/react-slot@1.0.2", "@radix-ui/react-slot@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
   integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==


### PR DESCRIPTION
### **요약 (Summary)**

admin 메인 페이지에 필요한 api를 연결하고 동작을 구현하였습니다.
+) 페이지네이션을 추가하였습니다.

### **목표 (Goals)**

- 추가하기를 누르면 새로운 row가 추가된다.
- 상품 링크를 입력하고 enter를 누르면 크롤링 요청 api를 통해 새로운 상품 정보가 추가된다.
- 추가된 정보는 최신순 정렬에 따라 가장 최상단에 위치하게 된다.
- 유튜브 링크를 입력하고 enter를 누르면 유튜브 url이 추가된다.
- Y/N에 Y or N을 입력하면 md 상품인지에 대한 정보가 추가된다.
- Y/N 이외의 입력을 하면 alert를 통해 경고가 뜬다.
- 보기 버튼을 클릭하면 해당 row에 대한 정보를 확인할 수 있다.
- pagination의 previous, next 버튼을 통해 이전 / 이후 페이지에 대한 정보를 확인할 수 있다.

### **마일스톤 (Milestones)**

24시간 내로 어드민 api 모두 연결하기 목표로 작업
