### PR TITLE
Feature#241.포인트 페이지 api 연결

### DIFF
--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -1,0 +1,12 @@
+import { PointsResponseDTO } from '@models/point/entity/response/pointResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
+
+export const getPoints = async (
+	page: number,
+): Promise<ApiResponse<PointsResponseDTO>> => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/buys?page=${page}`,
+	).then(res => res.json());
+
+	return response;
+};

--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -26,3 +26,14 @@ export const rejectPoint = async (id: TableDataId, rejectReason: string) => {
 
 	return response;
 };
+
+export const approvePoint = async (id: TableDataId) => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/buys/${id}/approve?buyId=${id}`,
+		{
+			method: 'PATCH',
+		},
+	).then(res => res.json());
+
+	return response;
+};

--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -1,11 +1,27 @@
 import { PointsResponseDTO } from '@models/point/entity/response/pointResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
+import { TableDataId } from '@type/table';
 
 export const getPoints = async (
 	page: number,
 ): Promise<ApiResponse<PointsResponseDTO>> => {
 	const response = await fetch(
 		`https://daldal.karmapol.link/api/v1/admin/buys?page=${page}`,
+	).then(res => res.json());
+
+	return response;
+};
+
+export const rejectPoint = async (id: TableDataId, rejectReason: string) => {
+	const response = await fetch(
+		`https://daldal.karmapol.link/api/v1/admin/buys/${id}/reject?buyId=${id}`,
+		{
+			method: 'PATCH',
+			body: JSON.stringify({ rejectReason }),
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		},
 	).then(res => res.json());
 
 	return response;

--- a/src/components/atoms/PagePagination.tsx
+++ b/src/components/atoms/PagePagination.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from 'react-router-dom';
+
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from '@components/ui/pagination';
+
+type PagePaginationProps = {
+	page: number;
+	lastPage: number;
+	route: '' | '/product' | '/point';
+};
+
+const PagePagination = ({ page, lastPage, route }: PagePaginationProps) => {
+	const navigate = useNavigate();
+
+	const handleGoPreviousPage = () => {
+		navigate(`${route}/${+page - 1 > 0 ? +page - 1 : 1}`);
+	};
+
+	const handleGoNextPage = () => {
+		navigate(`${route}/${+page + 1 <= lastPage ? +page + 1 : lastPage}`);
+	};
+
+	return (
+		<Pagination>
+			<PaginationContent>
+				<PaginationItem>
+					<PaginationPrevious
+						onClick={handleGoPreviousPage}
+						className="cursor-pointer"
+					>
+						Previous
+					</PaginationPrevious>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationLink>{page}</PaginationLink>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationEllipsis />
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationNext onClick={handleGoNextPage} className="cursor-pointer">
+						Next
+					</PaginationNext>
+				</PaginationItem>
+			</PaginationContent>
+		</Pagination>
+	);
+};
+
+export default PagePagination;

--- a/src/components/atoms/ShowDataButton.tsx
+++ b/src/components/atoms/ShowDataButton.tsx
@@ -7,6 +7,7 @@ import {
 	DialogTrigger,
 } from '@components/ui/dialog';
 import { useGetRowDataById } from '@hooks/data';
+import { useGetPageNumber } from '@hooks/page';
 import { defaultCrawlingData } from '@stores/tableData';
 import { TableDataId, TableDataKey } from '@type/table';
 
@@ -16,7 +17,9 @@ type ShowDataButtonProps = {
 };
 
 const ShowDataButton = ({ id, style }: ShowDataButtonProps) => {
-	const data = useGetRowDataById(id, ['adminItems']) || defaultCrawlingData;
+	const page = useGetPageNumber();
+	const data =
+		useGetRowDataById(id, ['adminItems', page]) || defaultCrawlingData;
 
 	const renderImageOrImages = (key: TableDataKey) => {
 		const dataInString = data[key as keyof typeof data].toString();

--- a/src/components/atoms/ShowImagesButton.tsx
+++ b/src/components/atoms/ShowImagesButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '@components/ui/dialog';
 
 type ShowImagesButtonProps = {
-	value: string[];
+	value: string;
 	style: string;
 };
 
@@ -20,11 +20,7 @@ const ShowImagesButton = ({ value, style }: ShowImagesButtonProps) => {
 				<DialogContent className="bg-White max-h-[calc(100%-50px)] overflow-auto">
 					<DialogHeader>인증 이미지 확인하기</DialogHeader>
 					<div className="flex flex-col w-full gap-4">
-						{value.map((image, index) => {
-							return (
-								<img src={image} alt="이미지" key={`ApprovalImage#${index}`} />
-							);
-						})}
+						<img src={value} alt="이미지" />
 					</div>
 				</DialogContent>
 			</Dialog>

--- a/src/components/atoms/Table.tsx
+++ b/src/components/atoms/Table.tsx
@@ -32,7 +32,7 @@ const Table = ({ columns, datas }: TableProps) => {
 										style={style}
 										isEditable={isEditable}
 										isClickable={isClickPossible}
-										key={`TableData#${key}`}
+										key={`TableData#${key}${data[key as keyof typeof data]}`}
 										id={data.id}
 									/>
 								);

--- a/src/components/atoms/TableData.tsx
+++ b/src/components/atoms/TableData.tsx
@@ -54,8 +54,8 @@ const TableData = ({
 	if (isClickable) {
 		if (headerKey === 'isOpen') {
 			return <ShowDataButton id={id} style={style} />;
-		} else if (headerKey === 'approvalImageUrls') {
-			return <ShowImagesButton value={value as string[]} style={style} />;
+		} else if (headerKey === 'certImageUrl') {
+			return <ShowImagesButton value={String(value)} style={style} />;
 		}
 	}
 

--- a/src/components/atoms/TableDataInput.tsx
+++ b/src/components/atoms/TableDataInput.tsx
@@ -6,7 +6,7 @@ import {
 	useRegisterSuggestedProduct,
 	useUnregisterSuggestedProduct,
 } from '@hooks/apis/item';
-import { useRejectPoint } from '@hooks/apis/point';
+import { useApprovePoint, useRejectPoint } from '@hooks/apis/point';
 import { TableDataId, TableDataKey, TableDataValue } from '@type/table';
 
 type TableDataInputProps = {
@@ -29,6 +29,7 @@ const TableDataInput = ({
 	const { registerSuggestedProduct } = useRegisterSuggestedProduct();
 	const { unregisterSuggestedProduct } = useUnregisterSuggestedProduct();
 	const { rejectPoint } = useRejectPoint();
+	const { approvePoint } = useApprovePoint();
 
 	const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setValue(event.target.value);
@@ -66,6 +67,16 @@ const TableDataInput = ({
 				}
 
 				rejectPoint({ id, rejectReason: String(value) || '' });
+			}
+
+			if (headerKey === 'refundStatus') {
+				if (value === 'Y') {
+					approvePoint({ id });
+				} else if (value === 'N') {
+					alert('N을 입력하면 거절 사유를 입력해주세요.');
+				} else {
+					alert('입력을 다시 확인해주세요.');
+				}
 			}
 		}
 	};

--- a/src/components/atoms/TableDataInput.tsx
+++ b/src/components/atoms/TableDataInput.tsx
@@ -6,6 +6,7 @@ import {
 	useRegisterSuggestedProduct,
 	useUnregisterSuggestedProduct,
 } from '@hooks/apis/item';
+import { useRejectPoint } from '@hooks/apis/point';
 import { TableDataId, TableDataKey, TableDataValue } from '@type/table';
 
 type TableDataInputProps = {
@@ -27,6 +28,7 @@ const TableDataInput = ({
 	const { addVideoUrl } = useAddVideoUrl();
 	const { registerSuggestedProduct } = useRegisterSuggestedProduct();
 	const { unregisterSuggestedProduct } = useUnregisterSuggestedProduct();
+	const { rejectPoint } = useRejectPoint();
 
 	const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setValue(event.target.value);
@@ -55,6 +57,14 @@ const TableDataInput = ({
 				} else {
 					alert('Y 또는 N을 입력해주세요.');
 				}
+			}
+
+			if (headerKey === 'rejectReason') {
+				if (value === '') {
+					alert('거절 사유를 입력해주세요.');
+				}
+
+				rejectPoint({ id, rejectReason: String(value) || '' });
 			}
 		}
 	};

--- a/src/components/atoms/TableDataInput.tsx
+++ b/src/components/atoms/TableDataInput.tsx
@@ -62,6 +62,7 @@ const TableDataInput = ({
 			if (headerKey === 'rejectReason') {
 				if (value === '') {
 					alert('거절 사유를 입력해주세요.');
+					return;
 				}
 
 				rejectPoint({ id, rejectReason: String(value) || '' });

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -13,7 +13,9 @@ const Routing = () => {
 				<Route path="/" element={<Main />} />
 				<Route path="/:page" element={<Main />} />
 				<Route path="/product" element={<Product />} />
+				<Route path="/product/:page" element={<Product />} />
 				<Route path="/point" element={<Point />} />
+				<Route path="/point/:page" element={<Point />} />
 			</Routes>
 		</BrowserRouter>
 	);

--- a/src/components/molcules/main/AddRowButton.tsx
+++ b/src/components/molcules/main/AddRowButton.tsx
@@ -1,15 +1,18 @@
 import { useQueryClient } from '@tanstack/react-query';
 
 import ButtonWithIcon from '@components/atoms/ButtonWithIcon';
+import { useGetPageNumber } from '@hooks/page';
 import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsResponseDTO';
 import { defaultCrawlingData } from '@stores/tableData';
 import { ApiResponse } from '@type/apiResponse';
 
 const AddRowButton = () => {
 	const queryClient = useQueryClient();
+	const page = useGetPageNumber();
+
 	const handleAddColumns = () => {
 		queryClient.setQueryData(
-			['adminItems'],
+			['adminItems', page],
 			(prev: ApiResponse<AdminItemsResponseDTO>) => ({
 				...prev,
 				data: {

--- a/src/components/organisms/point/CurrentRequestSection.tsx
+++ b/src/components/organisms/point/CurrentRequestSection.tsx
@@ -8,7 +8,9 @@ type CurrentRequestSectionProps = {
 };
 
 const CurrentRequestSection = ({ datas }: CurrentRequestSectionProps) => {
-	const notSelectedRequestdatas = datas.filter(data => data.isApproved === '');
+	const notSelectedRequestdatas = datas.filter(
+		data => data.refundStatus === 'IN_PROGRESS',
+	);
 
 	return (
 		<div className="h-1/2 overflow-auto">

--- a/src/components/organisms/point/PastRequestSection.tsx
+++ b/src/components/organisms/point/PastRequestSection.tsx
@@ -8,7 +8,9 @@ type PastRequestSectionProps = {
 };
 
 const PastRequestSection = ({ datas }: PastRequestSectionProps) => {
-	const selectedRequestdatas = datas.filter(data => data.isApproved !== '');
+	const selectedRequestdatas = datas.filter(
+		data => data.refundStatus !== 'IN_PROGRESS',
+	);
 
 	return (
 		<div className="h-1/2 overflow-auto">

--- a/src/components/templates/MainTable.tsx
+++ b/src/components/templates/MainTable.tsx
@@ -2,13 +2,17 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import CrawlingSection from '@components/organisms/main/CrawlingSection';
 import EnterDataSection from '@components/organisms/main/EnterDataSection';
+import { useGetPageNumber } from '@hooks/page';
 import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
 
 const MainTable = () => {
 	const queryClient = useQueryClient();
+	const page = useGetPageNumber();
+
 	const data = queryClient.getQueryData<ApiResponse<AdminItemsResponseDTO>>([
 		'adminItems',
+		page,
 	])?.data;
 
 	return (

--- a/src/constants/columns.ts
+++ b/src/constants/columns.ts
@@ -75,6 +75,6 @@ export const pointTableColumns: TableColumnList = [
 	{ name: '결제 시점', key: 'approvedTime', style: 'w-full' },
 	{ name: '구매액', key: 'purchase', style: 'w-full' },
 	{ name: '승인 포인트', key: 'refund', style: 'w-full' },
-	{ name: '승인 여부', key: 'refundStatus', style: 'w-full' },
+	{ name: '승인 여부', key: 'refundStatus', style: 'w-full', isEditable: true },
 	{ name: '사유', key: 'rejectReason', style: 'w-full', isEditable: true },
 ];

--- a/src/constants/columns.ts
+++ b/src/constants/columns.ts
@@ -64,17 +64,17 @@ export const userTableColumns: TableColumnList = [
 ];
 
 export const pointTableColumns: TableColumnList = [
-	{ name: '유저명', key: 'name', style: 'w-full' },
-	{ name: '요청 시간', key: 'refundRequestedDate', style: 'w-full' },
+	{ name: '유저명', key: 'memberId', style: 'w-full' },
+	{ name: '요청 시간', key: 'uploadTime', style: 'w-full' },
 	{
 		name: '이미지',
-		key: 'approvalImageUrls',
+		key: 'certImageUrl',
 		style: 'w-full',
 		isClickPossible: true,
 	},
-	{ name: '결제 시점', key: 'orderTime', style: 'w-full' },
-	{ name: '구매액', key: 'price', style: 'w-full' },
-	{ name: '승인 포인트', key: 'point', style: 'w-full' },
-	{ name: '승인 여부', key: 'isApproved', style: 'w-full' },
-	{ name: '사유', key: 'reason', style: 'w-full', isEditable: true },
+	{ name: '결제 시점', key: 'approvedTime', style: 'w-full' },
+	{ name: '구매액', key: 'purchase', style: 'w-full' },
+	{ name: '승인 포인트', key: 'refund', style: 'w-full' },
+	{ name: '승인 여부', key: 'refundStatus', style: 'w-full' },
+	{ name: '사유', key: 'rejectReason', style: 'w-full', isEditable: true },
 ];

--- a/src/hooks/apis/item.ts
+++ b/src/hooks/apis/item.ts
@@ -7,12 +7,13 @@ import {
 	registerSuggestedProduct,
 	unregisterSuggestedProduct,
 } from '@apis/item';
+import { useGetPageNumber } from '@hooks/page';
 import { AddYoutubeUrlRequestDTO } from '@models/crawling/request/addYoutubeUrlRequestDTO';
 import { TableDataId } from '@type/table';
 
 const useGetAdminItems = (page: number = 1) => {
 	return useQuery({
-		queryKey: ['adminItems'],
+		queryKey: ['adminItems', page],
 		queryFn: () => getAdminItems(page),
 		select: data => data.data,
 	});
@@ -20,11 +21,13 @@ const useGetAdminItems = (page: number = 1) => {
 
 const useCrawlAdminItems = () => {
 	const queryClient = useQueryClient();
+	const page = useGetPageNumber();
+
 	const { mutate } = useMutation({
-		mutationKey: ['adminItems'],
+		mutationKey: ['adminItems', page],
 		mutationFn: (url: string) => crawlAdminItems(url),
 		onSuccess: () =>
-			queryClient.invalidateQueries({ queryKey: ['adminItems'] }),
+			queryClient.invalidateQueries({ queryKey: ['adminItems', page] }),
 	});
 
 	return { crawlAdminItemsByUrl: mutate };
@@ -32,6 +35,7 @@ const useCrawlAdminItems = () => {
 
 const useAddVideoUrl = () => {
 	const queryClient = useQueryClient();
+
 	const { mutate } = useMutation({
 		mutationKey: ['adminItems'],
 		mutationFn: ({ url, id }: AddYoutubeUrlRequestDTO) => addVideoUrl(url, id),
@@ -44,6 +48,7 @@ const useAddVideoUrl = () => {
 
 const useRegisterSuggestedProduct = () => {
 	const queryClient = useQueryClient();
+
 	const { mutate } = useMutation({
 		mutationKey: ['adminItems'],
 		mutationFn: (id: TableDataId) => registerSuggestedProduct(id),
@@ -56,6 +61,7 @@ const useRegisterSuggestedProduct = () => {
 
 const useUnregisterSuggestedProduct = () => {
 	const queryClient = useQueryClient();
+
 	const { mutate } = useMutation({
 		mutationKey: ['adminItems'],
 		mutationFn: (id: TableDataId) => unregisterSuggestedProduct(id),

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getPoints, rejectPoint } from '@apis/point';
+import { approvePoint, getPoints, rejectPoint } from '@apis/point';
+import { ApprovePointRequest } from '@models/point/request/approvePointRequestDTO';
 import { RejectPointRequestDTO } from '@models/point/request/rejectPointRequestDTO';
 
 const useGetPoints = (page: number = 1) => {
@@ -23,4 +24,15 @@ const useRejectPoint = () => {
 	return { rejectPoint: mutate };
 };
 
-export { useGetPoints, useRejectPoint };
+const useApprovePoint = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation({
+		mutationKey: ['points'],
+		mutationFn: ({ id }: ApprovePointRequest) => approvePoint(id),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['points'] }),
+	});
+
+	return { approvePoint: mutate };
+};
+
+export { useGetPoints, useRejectPoint, useApprovePoint };

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -6,7 +6,7 @@ import { RejectPointRequestDTO } from '@models/point/request/rejectPointRequestD
 
 const useGetPoints = (page: number = 1) => {
 	return useQuery({
-		queryKey: ['points'],
+		queryKey: ['points', page],
 		queryFn: () => getPoints(page),
 		select: data => data.data,
 	});

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getPoints } from '@apis/point';
+
+const useGetPoints = (page: number = 1) => {
+	return useQuery({
+		queryKey: ['points'],
+		queryFn: () => getPoints(page),
+		select: data => data.data,
+	});
+};
+
+export { useGetPoints };

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getPoints } from '@apis/point';
+import { getPoints, rejectPoint } from '@apis/point';
+import { RejectPointRequestDTO } from '@models/point/request/rejectPointRequestDTO';
 
 const useGetPoints = (page: number = 1) => {
 	return useQuery({
@@ -10,4 +11,16 @@ const useGetPoints = (page: number = 1) => {
 	});
 };
 
-export { useGetPoints };
+const useRejectPoint = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation({
+		mutationKey: ['points'],
+		mutationFn: ({ id, rejectReason }: RejectPointRequestDTO) =>
+			rejectPoint(id, rejectReason),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['points'] }),
+	});
+
+	return { rejectPoint: mutate };
+};
+
+export { useGetPoints, useRejectPoint };

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -4,7 +4,10 @@ import { AdminItemsResponseDTO } from '@models/crawling/response/adminItemsRespo
 import { ApiResponse } from '@type/apiResponse';
 import { TableDataId } from '@type/table';
 
-export const useGetRowDataById = (id: TableDataId, queryKey: string[]) => {
+export const useGetRowDataById = (
+	id: TableDataId,
+	queryKey: (string | number)[],
+) => {
 	const queryClient = useQueryClient();
 	const data =
 		queryClient.getQueryData<ApiResponse<AdminItemsResponseDTO>>(queryKey)?.data

--- a/src/hooks/page.ts
+++ b/src/hooks/page.ts
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+export const useGetPageNumber = () => {
+	const params = useParams();
+	const page = params.page || 1;
+	return +page;
+};

--- a/src/models/point/entity/point.ts
+++ b/src/models/point/entity/point.ts
@@ -1,17 +1,15 @@
 import { TableDataId } from '@type/table';
 
-type IsApproved = true | false | '';
-
 export type PointTableData = {
 	id: TableDataId;
-	name: string;
-	refundRequestedDate: string;
-	approvalImageUrls: string[];
-	orderTime: string;
-	price: number;
-	point: number;
-	isApproved: IsApproved;
-	reason?: string;
+	memberId: string;
+	uploadTime: string;
+	approvedTime: string;
+	certImageUrl: string[];
+	purchase: number;
+	refund: number;
+	refundStatus: 'IN_PROGRESS' | 'COMPLETED' | 'REJECTED';
+	rejectReason?: string;
 };
 
 export type PointTableDataKey = keyof PointTableData;

--- a/src/models/point/entity/point.ts
+++ b/src/models/point/entity/point.ts
@@ -5,7 +5,7 @@ export type PointTableData = {
 	memberId: string;
 	uploadTime: string;
 	approvedTime: string;
-	certImageUrl: string[];
+	certImageUrl: string;
 	purchase: number;
 	refund: number;
 	refundStatus: 'IN_PROGRESS' | 'COMPLETED' | 'REJECTED';

--- a/src/models/point/entity/response/pointResponseDTO.ts
+++ b/src/models/point/entity/response/pointResponseDTO.ts
@@ -1,0 +1,6 @@
+import { PointTableDataList } from '@models/point/entity/point';
+
+export type PointsResponseDTO = {
+	pageNum: number;
+	buys: PointTableDataList;
+};

--- a/src/models/point/request/approvePointRequestDTO.ts
+++ b/src/models/point/request/approvePointRequestDTO.ts
@@ -1,0 +1,5 @@
+import { TableDataId } from '@type/table';
+
+export type ApprovePointRequest = {
+	id: TableDataId;
+};

--- a/src/models/point/request/rejectPointRequestDTO.ts
+++ b/src/models/point/request/rejectPointRequestDTO.ts
@@ -1,0 +1,6 @@
+import { TableDataId } from '@type/table';
+
+export type RejectPointRequestDTO = {
+	id: TableDataId;
+	rejectReason: string;
+};

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,24 +1,13 @@
-import { useParams } from 'react-router-dom';
-
+import PagePagination from '@components/atoms/PagePagination';
 import AddRowButton from '@components/molcules/main/AddRowButton';
 import MainTable from '@components/templates/MainTable';
-import {
-	Pagination,
-	PaginationContent,
-	PaginationEllipsis,
-	PaginationItem,
-	PaginationLink,
-	PaginationNext,
-	PaginationPrevious,
-} from '@components/ui/pagination';
 import { useGetAdminItems } from '@hooks/apis/item';
+import { useGetPageNumber } from '@hooks/page';
 import PageLayout from '@layouts/PageLayout';
 
 const Main = () => {
-	const params = useParams();
-
-	const page = params.page || 1;
-	const { data, isLoading, isError, error } = useGetAdminItems(+page);
+	const page = useGetPageNumber();
+	const { data, isLoading, isError, error } = useGetAdminItems(page);
 	const lastPage = data?.lastPageNum || 1;
 
 	if (isLoading) {
@@ -33,28 +22,7 @@ const Main = () => {
 		<PageLayout>
 			<AddRowButton />
 			<MainTable />
-			<Pagination>
-				<PaginationContent>
-					<PaginationItem>
-						<PaginationPrevious href={`${+page - 1 > 0 ? +page - 1 : 1}`}>
-							Previous
-						</PaginationPrevious>
-					</PaginationItem>
-					<PaginationItem>
-						<PaginationLink href={`${page}`}>{page}</PaginationLink>
-					</PaginationItem>
-					<PaginationItem>
-						<PaginationEllipsis />
-					</PaginationItem>
-					<PaginationItem>
-						<PaginationNext
-							href={`${+page + 1 <= lastPage ? +page + 1 : lastPage}`}
-						>
-							Next
-						</PaginationNext>
-					</PaginationItem>
-				</PaginationContent>
-			</Pagination>
+			<PagePagination page={page} lastPage={lastPage} route="" />
 		</PageLayout>
 	);
 };

--- a/src/pages/Point.tsx
+++ b/src/pages/Point.tsx
@@ -1,16 +1,8 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
+import PagePagination from '@components/atoms/PagePagination';
 import CurrentRequestSection from '@components/organisms/point/CurrentRequestSection';
 import PastRequestSection from '@components/organisms/point/PastRequestSection';
-import {
-	Pagination,
-	PaginationContent,
-	PaginationItem,
-	PaginationPrevious,
-	PaginationLink,
-	PaginationEllipsis,
-	PaginationNext,
-} from '@components/ui/pagination';
 import { useGetPoints } from '@hooks/apis/point';
 import PageLayout from '@layouts/PageLayout';
 
@@ -18,17 +10,8 @@ const Point = () => {
 	const params = useParams();
 	const page = params.page || 1;
 	const { data: datas, isLoading, isError, error } = useGetPoints(+page);
-	const navigate = useNavigate();
 
 	const lastPage = datas?.pageNum || 1;
-
-	const handleGoPreviousPage = () => {
-		navigate(`/point/${+page - 1 > 0 ? +page - 1 : 1}`);
-	};
-
-	const handleGoNextPage = () => {
-		navigate(`/point/${+page + 1 <= lastPage ? +page + 1 : lastPage}`);
-	};
 
 	if (isLoading) {
 		return <div>로딩중...</div>;
@@ -44,32 +27,7 @@ const Point = () => {
 				<CurrentRequestSection datas={datas?.buys || []} />
 				<PastRequestSection datas={datas?.buys || []} />
 			</div>
-			<Pagination>
-				<PaginationContent>
-					<PaginationItem>
-						<PaginationPrevious
-							onClick={handleGoPreviousPage}
-							className="cursor-pointer"
-						>
-							Previous
-						</PaginationPrevious>
-					</PaginationItem>
-					<PaginationItem>
-						<PaginationLink>{page}</PaginationLink>
-					</PaginationItem>
-					<PaginationItem>
-						<PaginationEllipsis />
-					</PaginationItem>
-					<PaginationItem>
-						<PaginationNext
-							onClick={handleGoNextPage}
-							className="cursor-pointer"
-						>
-							Next
-						</PaginationNext>
-					</PaginationItem>
-				</PaginationContent>
-			</Pagination>
+			<PagePagination page={+page} lastPage={lastPage} route="/point" />
 		</PageLayout>
 	);
 };

--- a/src/pages/Point.tsx
+++ b/src/pages/Point.tsx
@@ -1,18 +1,24 @@
 import CurrentRequestSection from '@components/organisms/point/CurrentRequestSection';
 import PastRequestSection from '@components/organisms/point/PastRequestSection';
+import { useGetPoints } from '@hooks/apis/point';
 import PageLayout from '@layouts/PageLayout';
-import { pointTableMockDataList } from '@mocks/point';
 
 const Point = () => {
-	// TODO: 데이터 get api 연결
+	const { data: datas, isLoading, isError, error } = useGetPoints();
 
-	const datas = pointTableMockDataList;
+	if (isLoading) {
+		return <div>로딩중...</div>;
+	}
+
+	if (isError) {
+		return <div>{error.message}</div>;
+	}
 
 	return (
 		<PageLayout>
 			<div className="h-full flex flex-col justify-between gap-10">
-				<CurrentRequestSection datas={datas} />
-				<PastRequestSection datas={datas} />
+				<CurrentRequestSection datas={datas?.buys || []} />
+				<PastRequestSection datas={datas?.buys || []} />
 			</div>
 		</PageLayout>
 	);

--- a/src/pages/Point.tsx
+++ b/src/pages/Point.tsx
@@ -1,15 +1,13 @@
-import { useParams } from 'react-router-dom';
-
 import PagePagination from '@components/atoms/PagePagination';
 import CurrentRequestSection from '@components/organisms/point/CurrentRequestSection';
 import PastRequestSection from '@components/organisms/point/PastRequestSection';
 import { useGetPoints } from '@hooks/apis/point';
+import { useGetPageNumber } from '@hooks/page';
 import PageLayout from '@layouts/PageLayout';
 
 const Point = () => {
-	const params = useParams();
-	const page = params.page || 1;
-	const { data: datas, isLoading, isError, error } = useGetPoints(+page);
+	const page = useGetPageNumber();
+	const { data: datas, isLoading, isError, error } = useGetPoints(page);
 
 	const lastPage = datas?.pageNum || 1;
 
@@ -27,7 +25,7 @@ const Point = () => {
 				<CurrentRequestSection datas={datas?.buys || []} />
 				<PastRequestSection datas={datas?.buys || []} />
 			</div>
-			<PagePagination page={+page} lastPage={lastPage} route="/point" />
+			<PagePagination page={page} lastPage={lastPage} route="/point" />
 		</PageLayout>
 	);
 };

--- a/src/pages/Point.tsx
+++ b/src/pages/Point.tsx
@@ -1,10 +1,34 @@
+import { useNavigate, useParams } from 'react-router-dom';
+
 import CurrentRequestSection from '@components/organisms/point/CurrentRequestSection';
 import PastRequestSection from '@components/organisms/point/PastRequestSection';
+import {
+	Pagination,
+	PaginationContent,
+	PaginationItem,
+	PaginationPrevious,
+	PaginationLink,
+	PaginationEllipsis,
+	PaginationNext,
+} from '@components/ui/pagination';
 import { useGetPoints } from '@hooks/apis/point';
 import PageLayout from '@layouts/PageLayout';
 
 const Point = () => {
-	const { data: datas, isLoading, isError, error } = useGetPoints();
+	const params = useParams();
+	const page = params.page || 1;
+	const { data: datas, isLoading, isError, error } = useGetPoints(+page);
+	const navigate = useNavigate();
+
+	const lastPage = datas?.pageNum || 1;
+
+	const handleGoPreviousPage = () => {
+		navigate(`/point/${+page - 1 > 0 ? +page - 1 : 1}`);
+	};
+
+	const handleGoNextPage = () => {
+		navigate(`/point/${+page + 1 <= lastPage ? +page + 1 : lastPage}`);
+	};
 
 	if (isLoading) {
 		return <div>로딩중...</div>;
@@ -20,6 +44,32 @@ const Point = () => {
 				<CurrentRequestSection datas={datas?.buys || []} />
 				<PastRequestSection datas={datas?.buys || []} />
 			</div>
+			<Pagination>
+				<PaginationContent>
+					<PaginationItem>
+						<PaginationPrevious
+							onClick={handleGoPreviousPage}
+							className="cursor-pointer"
+						>
+							Previous
+						</PaginationPrevious>
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationLink>{page}</PaginationLink>
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationEllipsis />
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationNext
+							onClick={handleGoNextPage}
+							className="cursor-pointer"
+						>
+							Next
+						</PaginationNext>
+					</PaginationItem>
+				</PaginationContent>
+			</Pagination>
 		</PageLayout>
 	);
 };

--- a/src/utils/formatData.ts
+++ b/src/utils/formatData.ts
@@ -4,13 +4,21 @@ export const getFormattedTableData = (
 	headerKey: TableDataKey,
 	value: TableDataValue,
 ) => {
+	const refundStatusMapping = {
+		IN_PROGRESS: '',
+		COMPLETED: 'Y',
+		REJECTED: 'N',
+	};
+
 	switch (headerKey) {
 		case 'isSuggested':
 			return value ? 'Y' : 'N';
 		case 'isRefund':
 			return value ? 'Y' : 'N';
-		case 'isApproved':
-			return value === true ? 'Y' : value === false ? 'N' : '';
+		case 'refundStatus':
+			return refundStatusMapping[
+				value as 'IN_PROGRESS' | 'COMPLETED' | 'REJECTED'
+			];
 		default:
 			return value;
 	}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
### **요약 (Summary)**

point 페이지 api를 연결하였습니다.

### **목표 (Goals)**

- 승인 여부에 따라 환급 요청 유저와 전체 유저의 목록을 확인할 수 있다.
- 승인 여부가 입력되지 않은 유저는 환급 요청 유저에, Y/N이 입력된 유저는 전체 유저에 위치한다.
- 관리자가 승인 여부에 Y/N 이외의 값을 입력하려고 하면 alert가 뜬다.
- 사유를 입력하면 승인 여부가 N 처리 된다.
- 사유 입력 없이 N을 입력하는 것도 alert가 뜬다.
- 이미지를 클릭하면 이미지를 확인할 수 있다.

### **목표가 아닌 것 (Non-Goals)**

- 현재 서버에서 결제 시점에 대한 데이터가 넘어오고 있지 않아서 승인 시점에 결제 시점을 표기하였습니다. api 응답이 변경되면 이 역시 변경하도록 하겠습니다.
- 구매액과 승인 포인트에 대한 요구사항이 변경되면서 승인 여부를 Y로 변경하는 동작이 동작할 수 없게 되었습니다.

### **마일스톤 (Milestones)**

오늘 내로 api 연결 다 끝내기